### PR TITLE
New syntax tests

### DIFF
--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -1,9 +1,9 @@
-(* SYNTAX TEST "Packages/WolframLanguage/WolframLanguage.sublime-syntax" *)
+(* SYNTAX TEST "WolframLanguage.sublime-syntax" *)
 
 (*
   For information on how this file is used, see
   https://www.sublimetext.com/docs/3/syntax.html#testing
-  Run tests by pressing `ctrl+shift+b`, i.e. run the `build` command
+  Run tests by pressing `ctrl+shift+b` (or `cmd+b` on macOS), i.e. run the `build` command
 *)
 
 (* NUMBERS *)
@@ -16,24 +16,137 @@
 (* ^^^ constant.numeric *)
    11.11
 (* ^^^^^ constant.numeric *)
+   11.11`
+(* ^^^^^^ constant.numeric *)
+   11.11`11.11
+(* ^^^^^^^^^^^ constant.numeric *)
 
+(* NUMERIC CONSTANTS *)
+
+   Catalan
+(* ^ constant.numeric *)
+   Pi
+(* ^ constant.numeric *)
+
+(* LANGUAGE CONSTANTS *)
+
+   True
+(* ^^^^ constant.language *)
+   Left
+(* ^^^^ constant.language *)
+
+(* OPERATORS *)
+
+  +
+(*^ keyword.operator.arithmetic*)
+  -
+(*^ keyword.operator.arithmetic*)
+  /
+(*^ keyword.operator.arithmetic*)
+  *
+(*^ keyword.operator.arithmetic*)
+
+  !
+(*^ keyword.operator.logical*)
+  &&
+(*^^ keyword.operator.logical*)
+  ||
+(*^^ keyword.operator.logical*)
+
+  >
+(*^ keyword.operator.comparison*)
+  <
+(*^ keyword.operator.comparison*)
+  ==
+(*^^ keyword.operator.comparison*)
+  >=
+(*^^ keyword.operator.comparison*)
+  <=
+(*^^ keyword.operator.comparison*)
+  ===
+(*^^^ keyword.operator.comparison*)
+  =!=
+(*^^^ keyword.operator.comparison*)
+
+   /;
+(* ^^ keyword.operator *)
+   //
+(* ^^ keyword.operator *)
+   /:
+(* ^^ keyword.operator *)
+   =
+(* ^ keyword.operator *)
+   :=
+(* ^^ keyword.operator *)
+   :>
+(* ^^ keyword.operator *)
+   ->
+(* ^^ keyword.operator *)
+   <->
+(* ^^^ keyword.operator *)
+
+(* VARIABLES *)
 
   f[x]
 (*^ variable.function*)
+  foo$bar12
+(*^^^^^^^^^ variable.other *)
+  $foo
+(*^^^^ variable.other *)
+  my`context12`$foo
+(*^^^^ variable.other *)
 
-  f[x_] := 2x
+  f[x];
+(*^ variable.function *)
+(*. ^ variable.other *)
+
+  Image[Red, Interleaving -> True]
+(*^^^^^ variable.function *)
+(*      ^ variable.function *)
+(*           ^ variable.function *)
+(*                        ^^ keyword.operator *)
+
+
+(* FUNCTIONS *)
+
+  f[x_, y_] := 2x
 (*^ entity.name.function*)
-(*  ^^ variable.parameter*)
-(*      ^^ keyword.operator*)
+(*  ^ variable.parameter*)
+(*      ^ variable.parameter*)
+(*          ^^ keyword.operator*)
 
   f[x_, OptionsPattern[]] := 2x
 (*^ entity.name.function*)
-(*  ^^ variable.parameter*)
+(*  ^ variable.parameter*)
 (*      ^^^^^^^^^^^^^^ variable.function*)
 (*                        ^^ keyword.operator*)
 
+  f[x_?TrueQ, y_ /; Negative[y]] := 2x /; y > 0
+(*^ entity.name.function*)
+(*  ^ variable.parameter*)
+(*    ^ keyword.operator*)
+(*               ^^ keyword.operator*)
 
 
+  f[x: _] := 2x
+(*^ entity.name.function*)
+(*  ^ variable.parameter*)
+
+(* <<< the scoping from above is breaking this one *)
+  f[x_] := 2x
+(*^ entity.name.function*)
+(*  ^ variable.parameter*)
+
+
+(* STRINGS *)
+
+  "This is a `string` (* this is not \a comment*)"
+(* ^ string.quoted.wolfram *)
+(*            ^ constant.other.placeholder *)
+(*                       ^ string.quoted.wolfram *)
+(*                                    ^ constant.character.escape *)
+
+(* ASSERTION FREE *)
 
   foo[[1]]
 


### PR DESCRIPTION
Some extra testing for the recent updates.
In the same order as they appear in the file

1. Stuff like `E` and `Pi` is really a numeric constant, not a function
2. If there is a comparison category, why are `<` and `>` not there?
3. `/;` and `/:` are not being parsed together as operators
4. `Red` cannot be a constant as it has evaluation semantic attached
5. I don't think options should have the same scope as function parameters
6. The patter at line 131 is breaking the definition scope (see test at 135)
7. Placeholder in strings are not supported

I think the most serous issue is the function definition scope at point 6.