### PR TITLE
Add support for boxes and templates

### DIFF
--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -49,7 +49,6 @@ variables:
 
   nb_code_styles: (Input)
 
-
 contexts:
 
   main:
@@ -105,14 +104,34 @@ contexts:
         - match: \"
           scope: punctuation.definition.string.end
           pop: true
-        - match: \\\[\w+\]
+
+        # box representation
+        - match: \\!\\\(
+          scope: keyword.operator.string-box.wolfram
+          push:
+            # workaround plain scope in string meta scope
+            - meta_scope: string.unquoted.yaml meta.string-box.wolfram
+            - match: \\\)
+              scope: keyword.operator.string-box.wolfram
+              pop: true
+            - include: boxed
+
+        # escape characters
+        - match: \\([nrtb]|\r?\n)
           scope: constant.character.escape.wolfram
-        - match: \\[()!*]
-          scope: keyword.operator.wolfram
-        - match: \\[^()!*]
-          scope: constant.character.escape.wolfram
-        - match: (?<=[\s\"\`])\`\w*\`
-          scope: constant.other.placeholder.wolfram
+
+        # string template
+        - match: \`\w*\`
+          scope: variable.parameter.wolfram
+        - match: <\*
+          scope: keyword.operator.template-expression.wolfram
+          push:
+            # workaround plain scope in string meta scope
+            - meta_scope: string.unquoted.yaml meta.template-expression.wolfram
+            - match: \*>
+              scope: keyword.operator.template-expression.wolfram
+              pop: true
+            - include: expressions
 
   shorthand:
     - match: (::)\s*([[:alnum:]]+)
@@ -249,7 +268,6 @@ contexts:
       pop: true
     - include: expressions
 
-
   declarations:
     - match: |-
         (?x)
@@ -330,3 +348,26 @@ contexts:
           scope: punctuation.section.association.end.wolfram
           pop: true
         - include: expressions
+    - match: (\\!)?\\\(
+      scope: punctuation.section.box.begin.wolfram
+      push:
+        - meta_scope: meta.box.wolfram
+        - match: \\\)
+          scope: punctuation.section.box.end.wolfram
+          pop: true
+        - include: boxed
+
+  boxed:
+    - include: expressions
+    - match: \\[%&+_^]
+      scope: keyword.operator.x-scriptBox.wolfram
+    - match: \\/
+      scope: keyword.operator.FractionBox.wolfram
+    - match: \\@
+      scope: keyword.operator.SqrtBox.wolfram
+    - match: \\`
+      scope: keyword.operator.FormBox.wolfram
+    - match: \\\*
+      scope: keyword.operator.box-constructor.wolfram
+      push: expressions
+

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -98,11 +98,10 @@ contexts:
     - match: ((?:System`)?{{built_in_options}})
       scope: variable.function.wolfram
     - match: \"
-      scope: punctuation.definition.string.begin
+      scope: string.quoted.wolfram punctuation.definition.string.begin
       push:
-        - meta_scope: string.quoted.wolfram
         - match: \"
-          scope: punctuation.definition.string.end
+          scope: string.quoted.wolfram punctuation.definition.string.end
           pop: true
 
         # box representation
@@ -110,14 +109,16 @@ contexts:
           scope: keyword.operator.string-box.wolfram
           push:
             # workaround plain scope in string meta scope
-            - meta_scope: string.unquoted.yaml meta.string-box.wolfram
+            - meta_scope: meta.string-box.wolfram
             - match: \\\)
               scope: keyword.operator.string-box.wolfram
+              pop: true
+            - match: (?=\")
               pop: true
             - include: boxed
 
         # escape characters
-        - match: \\([nrtb]|\r?\n)
+        - match: \\(["nrtbf\\]|\r?\n)
           scope: constant.character.escape.wolfram
         - match: \\\.[0-9A-Fa-f]{2}|\\:[0-9A-Fa-f]{4}
           scope: constant.character.encoding.wolfram
@@ -131,11 +132,16 @@ contexts:
           scope: keyword.operator.template-expression.wolfram
           push:
             # workaround plain scope in string meta scope
-            - meta_scope: string.unquoted.yaml meta.template-expression.wolfram
+            - meta_scope: meta.template-expression.wolfram
             - match: \*>
               scope: keyword.operator.template-expression.wolfram
               pop: true
+            - match: (?=\")
+              pop: true
             - include: expressions
+
+        - match: '[\s\S]'
+          scope: string.quoted.wolfram
 
   shorthand:
     - match: (::)\s*([[:alnum:]]+)
@@ -373,5 +379,3 @@ contexts:
       scope: keyword.operator.FormBox.wolfram
     - match: \\\*
       scope: keyword.operator.box-constructor.wolfram
-      push: expressions
-

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -135,7 +135,7 @@ contexts:
         - include: boxed
 
     # escape characters
-    - match: \\[-"nrtbf()!^%&+_*@`/\\]
+    - match: \\[nrtbf()"!^%&+_*@`/\\]
       scope: constant.character.escape.wolfram
     - match: |-
         (?x)(

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -74,9 +74,9 @@ contexts:
     - match: '(\(\*\s*)(::)([[:alnum:]]+)(::)(\s*\*\))'
       captures:
         1: comment.line.wolfram
-        2: constant.numeric.line-number.find-in-files
-        3: constant.language.wolfram
-        4: constant.numeric.line-number.find-in-files
+        2: constant.numeric.line-number.find-in-files punctuation.style.begin.wolfram
+        3: constant.language.style.wolfram
+        4: constant.numeric.line-number.find-in-files punctuation.style.end.wolfram
         5: comment.line.wolfram
     - match: \(\*
       push: comment-block

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -62,6 +62,7 @@ contexts:
     - include: expressions
 
   prototype:
+    # ignore the following newline after a back-slant
     - match: \\\r?\n
 
   expressions:
@@ -135,7 +136,7 @@ contexts:
         - include: boxed
 
     # escape characters
-    - match: \\[nrtbf()"!^%&+_*@`/\\]
+    - match: \\[ !"%&()*+/@\\^_`bfnrt<>]
       scope: constant.character.escape.wolfram
     - match: |-
         (?x)(
@@ -155,9 +156,9 @@ contexts:
           \\:[0-9A-Fa-f]{0,3}(?=[^0-9A-Fa-f])
         )
       scope: invalid.character.encoding.wolfram
-    - match: \\\[\w+\]
+    - match: \\\[\w*\]
       scope: invalid.character.built-in.wolfram
-    - match: \\[a-zA-Z]
+    - match: \\[a-zA-Z\[]
       scope: invalid.character.escape.wolfram
 
   string:

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -119,7 +119,7 @@ contexts:
         # escape characters
         - match: \\([nrtb]|\r?\n)
           scope: constant.character.escape.wolfram
-        - match: \\:\w{4}
+        - match: \\\.[0-9A-Fa-f]{2}|\\:[0-9A-Fa-f]{4}
           scope: constant.character.encoding.wolfram
         - match: \\\[\w+\]
           scope: constant.character.built-in.wolfram

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -55,6 +55,9 @@ contexts:
     - include: declarations
     - include: expressions
 
+  prototype:
+    - match: \\\r?\n
+
   expressions:
     - include: pattern
     - include: expressions-nopattern
@@ -126,7 +129,7 @@ contexts:
         - include: boxed
 
     # escape characters
-    - match: \\(["nrtbf\\]|\r?\n)
+    - match: \\["nrtbf\\]
       scope: constant.character.escape.wolfram
     - match: \\\.[0-9A-Fa-f]{2}|\\:[0-9A-Fa-f]{4}
       scope: constant.character.encoding.wolfram

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -99,49 +99,56 @@ contexts:
       scope: variable.function.wolfram
     - match: \"
       scope: string.quoted.wolfram punctuation.definition.string.begin
+      push: string
+
+  inside-string:
+    - match: (?=")
+      pop: true
+    - match: \\\"
+      scope: string.quoted.wolfram punctuation.definition.string.begin
+      push: string
+
+  string:
+    - match: \"
+      scope: string.quoted.wolfram punctuation.definition.string.end
+      pop: true
+
+    # box representation
+    - match: \\!\\\(
+      scope: keyword.operator.string-box.wolfram
       push:
-        - match: \"
-          scope: string.quoted.wolfram punctuation.definition.string.end
-          pop: true
-
-        # box representation
-        - match: \\!\\\(
+        # workaround plain scope in string meta scope
+        - meta_scope: meta.string-box.wolfram
+        - match: \\\)
           scope: keyword.operator.string-box.wolfram
-          push:
-            # workaround plain scope in string meta scope
-            - meta_scope: meta.string-box.wolfram
-            - match: \\\)
-              scope: keyword.operator.string-box.wolfram
-              pop: true
-            - match: (?=\")
-              pop: true
-            - include: boxed
+          pop: true
+        - include: inside-string
+        - include: boxed
 
-        # escape characters
-        - match: \\(["nrtbf\\]|\r?\n)
-          scope: constant.character.escape.wolfram
-        - match: \\\.[0-9A-Fa-f]{2}|\\:[0-9A-Fa-f]{4}
-          scope: constant.character.encoding.wolfram
-        - match: \\\[\w+\]
-          scope: constant.character.built-in.wolfram
+    # escape characters
+    - match: \\(["nrtbf\\]|\r?\n)
+      scope: constant.character.escape.wolfram
+    - match: \\\.[0-9A-Fa-f]{2}|\\:[0-9A-Fa-f]{4}
+      scope: constant.character.encoding.wolfram
+    - match: \\\[\w+\]
+      scope: constant.character.built-in.wolfram
 
-        # string template
-        - match: \`\w*\`
-          scope: variable.parameter.wolfram
-        - match: <\*
+    # string template
+    - match: \`\w*\`
+      scope: variable.parameter.wolfram
+    - match: <\*
+      scope: keyword.operator.template-expression.wolfram
+      push:
+        # workaround plain scope in string meta scope
+        - meta_scope: meta.template-expression.wolfram
+        - match: \*>
           scope: keyword.operator.template-expression.wolfram
-          push:
-            # workaround plain scope in string meta scope
-            - meta_scope: meta.template-expression.wolfram
-            - match: \*>
-              scope: keyword.operator.template-expression.wolfram
-              pop: true
-            - match: (?=\")
-              pop: true
-            - include: expressions
+          pop: true
+        - include: inside-string
+        - include: expressions
 
-        - match: '[\s\S]'
-          scope: string.quoted.wolfram
+    - match: '[\s\S]'
+      scope: string.quoted.wolfram
 
   shorthand:
     - match: (::)\s*([[:alnum:]]+)

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -47,6 +47,12 @@ variables:
       Catalan|Degree|E|EulerGamma|Glaisher|GoldenAngle|GoldenRatio|I|Khinchin|MachinePrecision|Pi
     )\b
 
+  named_characters: AAcute|ABar|ACup|ADoubleDot|AE|AGrave|AHat|Aleph|AliasDelimiter|AliasIndicator|AlignmentMarker|Alpha|AltKey|And|Angle|Angstrom|AquariusSign|AriesSign|ARing|AscendingEllipsis|ATilde|AutoLeftMatch|AutoOperand|AutoPlaceholder|AutoRightMatch|AutoSpace|Backslash|BeamedEighthNote|BeamedSixteenthNote|Because|Bet|Beta|BlackBishop|BlackKing|BlackKnight|BlackPawn|BlackQueen|BlackRook|Breve|Bullet|CAcute|CancerSign|Cap|CapitalAAcute|CapitalABar|CapitalACup|CapitalADoubleDot|CapitalAE|CapitalAGrave|CapitalAHat|CapitalAlpha|CapitalARing|CapitalATilde|CapitalBeta|CapitalCAcute|CapitalCCedilla|CapitalCHacek|CapitalChi|CapitalDelta|CapitalDHacek|CapitalDifferentialD|CapitalDigamma|CapitalEAcute|CapitalEBar|CapitalECup|CapitalEDoubleDot|CapitalEGrave|CapitalEHacek|CapitalEHat|CapitalEpsilon|CapitalEta|CapitalEth|CapitalGamma|CapitalIAcute|CapitalICup|CapitalIDoubleDot|CapitalIGrave|CapitalIHat|CapitalIota|CapitalKappa|CapitalKoppa|CapitalLambda|CapitalLSlash|CapitalMu|CapitalNHacek|CapitalNTilde|CapitalNu|CapitalOAcute|CapitalODoubleAcute|CapitalODoubleDot|CapitalOE|CapitalOGrave|CapitalOHat|CapitalOmega|CapitalOmicron|CapitalOSlash|CapitalOTilde|CapitalPhi|CapitalPi|CapitalPsi|CapitalRHacek|CapitalRho|CapitalSampi|CapitalSHacek|CapitalSigma|CapitalStigma|CapitalTau|CapitalTHacek|CapitalTheta|CapitalThorn|CapitalUAcute|CapitalUDoubleAcute|CapitalUDoubleDot|CapitalUGrave|CapitalUHat|CapitalUpsilon|CapitalURing|CapitalXi|CapitalYAcute|CapitalZeta|CapitalZHacek|CapricornSign|CCedilla|Cedilla|CenterDot|CenterEllipsis|Cent|CHacek|CheckedBox|Checkmark|Chi|CircleDot|CircleMinus|CirclePlus|CircleTimes|ClockwiseContourIntegral|CloseCurlyDoubleQuote|CloseCurlyQuote|CloverLeaf|ClubSuit|Colon|CommandKey|Conditioned|Congruent|Conjugate|ConjugateTranspose|ConstantC|Continuation|ContourIntegral|ControlKey|Coproduct|Copyright|CounterClockwiseContourIntegral|Cross|CupCap|Cup|CurlyCapitalUpsilon|CurlyEpsilon|CurlyKappa|CurlyPhi|CurlyPi|CurlyRho|CurlyTheta|Currency|Dagger|Dalet|Dash|Degree|DeleteKey|Del|Delta|DescendingEllipsis|DHacek|Diameter|Diamond|DiamondSuit|DifferenceDelta|DifferentialD|Digamma|DirectedEdge|DiscreteRatio|DiscreteShift|DiscretionaryHyphen|DiscretionaryLineSeparator|DiscretionaryPageBreakAbove|DiscretionaryPageBreakBelow|DiscretionaryParagraphSeparator|Distributed|Divides|Divide|DotEqual|DotlessI|DotlessJ|DottedSquare|DoubleContourIntegral|DoubleDagger|DoubledGamma|DoubleDot|DoubleDownArrow|DoubledPi|DoubleLeftArrow|DoubleLeftRightArrow|DoubleLeftTee|DoubleLongLeftArrow|DoubleLongLeftRightArrow|DoubleLongRightArrow|DoublePrime|DoubleRightArrow|DoubleRightTee|DoubleStruckA|DoubleStruckB|DoubleStruckC|DoubleStruckCapitalA|DoubleStruckCapitalB|DoubleStruckCapitalC|DoubleStruckCapitalD|DoubleStruckCapitalE|DoubleStruckCapitalF|DoubleStruckCapitalG|DoubleStruckCapitalH|DoubleStruckCapitalI|DoubleStruckCapitalJ|DoubleStruckCapitalK|DoubleStruckCapitalL|DoubleStruckCapitalM|DoubleStruckCapitalN|DoubleStruckCapitalO|DoubleStruckCapitalP|DoubleStruckCapitalQ|DoubleStruckCapitalR|DoubleStruckCapitalS|DoubleStruckCapitalT|DoubleStruckCapitalU|DoubleStruckCapitalV|DoubleStruckCapitalW|DoubleStruckCapitalX|DoubleStruckCapitalY|DoubleStruckCapitalZ|DoubleStruckD|DoubleStruckE|DoubleStruckEight|DoubleStruckF|DoubleStruckFive|DoubleStruckFour|DoubleStruckG|DoubleStruckH|DoubleStruckI|DoubleStruckJ|DoubleStruckK|DoubleStruckL|DoubleStruckM|DoubleStruckN|DoubleStruckNine|DoubleStruckO|DoubleStruckOne|DoubleStruckP|DoubleStruckQ|DoubleStruckR|DoubleStruckS|DoubleStruckSeven|DoubleStruckSix|DoubleStruckT|DoubleStruckThree|DoubleStruckTwo|DoubleStruckU|DoubleStruckV|DoubleStruckW|DoubleStruckX|DoubleStruckY|DoubleStruckZ|DoubleStruckZero|DoubleUpArrow|DoubleUpDownArrow|DoubleVerticalBar|DownArrowBar|DownArrow|DownArrowUpArrow|DownBreve|DownExclamation|DownLeftRightVector|DownLeftTeeVector|DownLeftVector|DownLeftVectorBar|DownPointer|DownQuestion|DownRightTeeVector|DownRightVector|DownRightVectorBar|DownTeeArrow|DownTee|EAcute|Earth|EBar|ECup|EDoubleDot|EGrave|EHacek|EHat|EighthNote|Element|Ellipsis|EmptyCircle|EmptyDiamond|EmptyDownTriangle|EmptyRectangle|EmptySet|EmptySmallCircle|EmptySmallSquare|EmptySquare|EmptyUpTriangle|EmptyVerySmallSquare|EnterKey|EntityEnd|EntityStart|Epsilon|Equal|EqualTilde|Equilibrium|Equivalent|ErrorIndicator|EscapeKey|Eta|Eth|Euro|Exists|ExponentialE|FiLigature|FilledCircle|FilledDiamond|FilledDownTriangle|FilledLeftTriangle|FilledRectangle|FilledRightTriangle|FilledSmallCircle|FilledSmallSquare|FilledSquare|FilledUpTriangle|FilledVerySmallSquare|FinalSigma|FirstPage|FivePointedStar|Flat|FlLigature|Florin|ForAll|FormalA|FormalAlpha|FormalB|FormalBeta|FormalC|FormalCapitalA|FormalCapitalAlpha|FormalCapitalB|FormalCapitalBeta|FormalCapitalC|FormalCapitalChi|FormalCapitalD|FormalCapitalDelta|FormalCapitalDigamma|FormalCapitalE|FormalCapitalEpsilon|FormalCapitalEta|FormalCapitalF|FormalCapitalG|FormalCapitalGamma|FormalCapitalH|FormalCapitalI|FormalCapitalIota|FormalCapitalJ|FormalCapitalK|FormalCapitalKappa|FormalCapitalKoppa|FormalCapitalL|FormalCapitalLambda|FormalCapitalM|FormalCapitalMu|FormalCapitalN|FormalCapitalNu|FormalCapitalO|FormalCapitalOmega|FormalCapitalOmicron|FormalCapitalP|FormalCapitalPhi|FormalCapitalPi|FormalCapitalPsi|FormalCapitalQ|FormalCapitalR|FormalCapitalRho|FormalCapitalS|FormalCapitalSampi|FormalCapitalSigma|FormalCapitalStigma|FormalCapitalT|FormalCapitalTau|FormalCapitalTheta|FormalCapitalU|FormalCapitalUpsilon|FormalCapitalV|FormalCapitalW|FormalCapitalX|FormalCapitalXi|FormalCapitalY|FormalCapitalZ|FormalCapitalZeta|FormalChi|FormalCurlyCapitalUpsilon|FormalCurlyEpsilon|FormalCurlyKappa|FormalCurlyPhi|FormalCurlyPi|FormalCurlyRho|FormalCurlyTheta|FormalD|FormalDelta|FormalDigamma|FormalE|FormalEpsilon|FormalEta|FormalF|FormalFinalSigma|FormalG|FormalGamma|FormalH|FormalI|FormalIota|FormalJ|FormalK|FormalKappa|FormalKoppa|FormalL|FormalLambda|FormalM|FormalMu|FormalN|FormalNu|FormalO|FormalOmega|FormalOmicron|FormalP|FormalPhi|FormalPi|FormalPsi|FormalQ|FormalR|FormalRho|FormalS|FormalSampi|FormalSigma|FormalStigma|FormalT|FormalTau|FormalTheta|FormalU|FormalUpsilon|FormalV|FormalW|FormalX|FormalXi|FormalY|FormalZ|FormalZeta|FreakedSmiley|Function|Gamma|GeminiSign|Gimel|GothicA|GothicB|GothicC|GothicCapitalA|GothicCapitalB|GothicCapitalC|GothicCapitalD|GothicCapitalE|GothicCapitalF|GothicCapitalG|GothicCapitalH|GothicCapitalI|GothicCapitalJ|GothicCapitalK|GothicCapitalL|GothicCapitalM|GothicCapitalN|GothicCapitalO|GothicCapitalP|GothicCapitalQ|GothicCapitalR|GothicCapitalS|GothicCapitalT|GothicCapitalU|GothicCapitalV|GothicCapitalW|GothicCapitalX|GothicCapitalY|GothicCapitalZ|GothicD|GothicE|GothicEight|GothicF|GothicFive|GothicFour|GothicG|GothicH|GothicI|GothicJ|GothicK|GothicL|GothicM|GothicN|GothicNine|GothicO|GothicOne|GothicP|GothicQ|GothicR|GothicS|GothicSeven|GothicSix|GothicT|GothicThree|GothicTwo|GothicU|GothicV|GothicW|GothicX|GothicY|GothicZ|GothicZero|GrayCircle|GraySquare|GreaterEqualLess|GreaterEqual|GreaterFullEqual|GreaterGreater|GreaterLess|GreaterSlantEqual|GreaterTilde|Hacek|HappySmiley|HBar|HeartSuit|HermitianConjugate|HorizontalLine|HumpDownHump|HumpEqual|Hyphen|IAcute|ICup|IDoubleDot|IGrave|IHat|ImaginaryI|ImaginaryJ|ImplicitPlus|Implies|IndentingNewLine|Infinity|Integral|Intersection|InvisibleApplication|InvisibleComma|InvisiblePostfixScriptBase|InvisiblePrefixScriptBase|InvisibleSpace|InvisibleTimes|Iota|Jupiter|Kappa|KernelIcon|Koppa|Lambda|LastPage|LeftAngleBracket|LeftArrowBar|LeftArrow|LeftArrowRightArrow|LeftAssociation|LeftBracketingBar|LeftCeiling|LeftDoubleBracket|LeftDoubleBracketingBar|LeftDownTeeVector|LeftDownVectorBar|LeftDownVector|LeftFloor|LeftGuillemet|LeftModified|LeftPointer|LeftRightArrow|LeftRightVector|LeftSkeleton|LeftTee|LeftTeeArrow|LeftTeeVector|LeftTriangle|LeftTriangleBar|LeftTriangleEqual|LeftUpDownVector|LeftUpTeeVector|LeftUpVector|LeftUpVectorBar|LeftVector|LeftVectorBar|LeoSign|LessEqual|LessEqualGreater|LessFullEqual|LessGreater|LessLess|LessSlantEqual|LessTilde|LetterSpace|LibraSign|LightBulb|LineSeparator|LongDash|LongEqual|LongLeftArrow|LongLeftRightArrow|LongRightArrow|LowerLeftArrow|LowerRightArrow|LSlash|Mars|MathematicaIcon|MeasuredAngle|MediumSpace|Mercury|Mho|Micro|MinusPlus|Mu|Nand|Natural|NegativeMediumSpace|NegativeThickSpace|NegativeThinSpace|NegativeVeryThinSpace|Neptune|NestedGreaterGreater|NestedLessLess|NeutralSmiley|NewLine|NHacek|NoBreak|NonBreakingSpace|Nor|NotCongruent|NotCupCap|NotDoubleVerticalBar|NotElement|NotEqual|NotEqualTilde|NotExists|NotGreater|NotGreaterEqual|NotGreaterFullEqual|NotGreaterGreater|NotGreaterLess|NotGreaterSlantEqual|NotGreaterTilde|NotHumpDownHump|NotHumpEqual|NotLeftTriangle|NotLeftTriangleBar|NotLeftTriangleEqual|NotLessEqual|NotLessFullEqual|NotLessGreater|NotLess|NotLessLess|NotLessSlantEqual|NotLessTilde|Not|NotNestedGreaterGreater|NotNestedLessLess|NotPrecedes|NotPrecedesEqual|NotPrecedesSlantEqual|NotPrecedesTilde|NotReverseElement|NotRightTriangle|NotRightTriangleBar|NotRightTriangleEqual|NotSquareSubset|NotSquareSubsetEqual|NotSquareSuperset|NotSquareSupersetEqual|NotSubset|NotSubsetEqual|NotSucceeds|NotSucceedsEqual|NotSucceedsSlantEqual|NotSucceedsTilde|NotSuperset|NotSupersetEqual|NotTilde|NotTildeEqual|NotTildeFullEqual|NotTildeTilde|NotVerticalBar|NTilde|Nu|Null|NumberSign|OAcute|ODoubleAcute|ODoubleDot|OE|OGrave|OHat|Omega|Omicron|OpenCurlyDoubleQuote|OpenCurlyQuote|OptionKey|Or|OSlash|OTilde|OverBrace|OverBracket|OverParenthesis|Paragraph|ParagraphSeparator|PartialD|PermutationProduct|Phi|Pi|Piecewise|PiscesSign|Placeholder|PlusMinus|Pluto|Precedes|PrecedesEqual|PrecedesSlantEqual|PrecedesTilde|Prime|Product|Proportion|Proportional|Psi|QuarterNote|RawAmpersand|RawAt|RawBackquote|RawBackslash|RawColon|RawComma|RawDash|RawDollar|RawDot|RawDoubleQuote|RawEqual|RawEscape|RawExclamation|RawGreater|RawLeftBrace|RawLeftBracket|RawLeftParenthesis|RawLess|RawNumberSign|RawPercent|RawPlus|RawQuestion|RawQuote|RawReturn|RawRightBrace|RawRightBracket|RawRightParenthesis|RawSemicolon|RawSlash|RawSpace|RawStar|RawTab|RawTilde|RawUnderscore|RawVerticalBar|RawWedge|RegisteredTrademark|ReturnIndicator|ReturnKey|ReverseDoublePrime|ReverseElement|ReverseEquilibrium|ReversePrime|ReverseUpEquilibrium|RHacek|Rho|RightAngle|RightAngleBracket|RightArrow|RightArrowBar|RightArrowLeftArrow|RightAssociation|RightBracketingBar|RightCeiling|RightDoubleBracket|RightDoubleBracketingBar|RightDownTeeVector|RightDownVector|RightDownVectorBar|RightFloor|RightGuillemet|RightModified|RightPointer|RightSkeleton|RightTee|RightTeeArrow|RightTeeVector|RightTriangle|RightTriangleBar|RightTriangleEqual|RightUpDownVector|RightUpTeeVector|RightUpVector|RightUpVectorBar|RightVector|RightVectorBar|RoundImplies|RoundSpaceIndicator|Rule|RuleDelayed|SadSmiley|SagittariusSign|Sampi|Saturn|ScorpioSign|ScriptA|ScriptB|ScriptC|ScriptCapitalA|ScriptCapitalB|ScriptCapitalC|ScriptCapitalD|ScriptCapitalE|ScriptCapitalF|ScriptCapitalG|ScriptCapitalH|ScriptCapitalI|ScriptCapitalJ|ScriptCapitalK|ScriptCapitalL|ScriptCapitalM|ScriptCapitalN|ScriptCapitalO|ScriptCapitalP|ScriptCapitalQ|ScriptCapitalR|ScriptCapitalS|ScriptCapitalT|ScriptCapitalU|ScriptCapitalV|ScriptCapitalW|ScriptCapitalX|ScriptCapitalY|ScriptCapitalZ|ScriptD|ScriptDotlessI|ScriptDotlessJ|ScriptE|ScriptEight|ScriptF|ScriptFive|ScriptFour|ScriptG|ScriptH|ScriptI|ScriptJ|ScriptK|ScriptL|ScriptM|ScriptN|ScriptNine|ScriptO|ScriptOne|ScriptP|ScriptQ|ScriptR|ScriptS|ScriptSeven|ScriptSix|ScriptT|ScriptThree|ScriptTwo|ScriptU|ScriptV|ScriptW|ScriptX|ScriptY|ScriptZ|ScriptZero|Section|SelectionPlaceholder|SHacek|Sharp|ShortDownArrow|ShortLeftArrow|ShortRightArrow|ShortUpArrow|Sigma|SixPointedStar|SkeletonIndicator|SmallCircle|SpaceIndicator|SpaceKey|SpadeSuit|SpanFromAbove|SpanFromBoth|SpanFromLeft|SphericalAngle|Sqrt|Square|SquareIntersection|SquareSubset|SquareSubsetEqual|SquareSuperset|SquareSupersetEqual|SquareUnion|Star|Sterling|Stigma|Subset|SubsetEqual|Succeeds|SucceedsEqual|SucceedsSlantEqual|SucceedsTilde|SuchThat|Sum|Superset|SupersetEqual|SystemEnterKey|SystemsModelDelay|SZ|TabKey|Tau|TaurusSign|TensorProduct|TensorWedge|THacek|Therefore|Theta|ThickSpace|ThinSpace|Thorn|Tilde|TildeEqual|TildeFullEqual|TildeTilde|Times|Trademark|Transpose|TripleDot|UAcute|UDoubleAcute|UDoubleDot|UGrave|UHat|UnderBrace|UnderBracket|UnderParenthesis|UndirectedEdge|Union|UnionPlus|UpArrow|UpArrowBar|UpArrowDownArrow|UpDownArrow|UpEquilibrium|UpperLeftArrow|UpperRightArrow|UpPointer|Upsilon|UpTee|UpTeeArrow|Uranus|URing|Vee|Venus|VerticalBar|VerticalEllipsis|VerticalLine|VerticalSeparator|VerticalTilde|VeryThinSpace|VirgoSign|WarningSign|WatchIcon|Wedge|WeierstrassP|WhiteBishop|WhiteKing|WhiteKnight|WhitePawn|WhiteQueen|WhiteRook|Wolf|WolframLanguageLogo|WolframLanguageLogoCircle|Xi|Xnor|Xor|YAcute|YDoubleDot|Yen|Zeta|ZHacek
+
+  scoping_functions: Block|Module|With|Function
+
+  string_template_functions: StringTemplate|TemplateApply
+
   nb_code_styles: (Input)
 
 contexts:
@@ -111,7 +117,7 @@ contexts:
       scope: string.quoted.wolfram punctuation.definition.string.begin
       push: string
 
-  string:
+  general-string:
     - match: \"
       scope: string.quoted.wolfram punctuation.definition.string.end
       pop: true
@@ -129,14 +135,38 @@ contexts:
         - include: boxed
 
     # escape characters
-    - match: \\["nrtbf\\]
+    - match: \\[-"nrtbf()!^%&+_*@`/\\]
       scope: constant.character.escape.wolfram
-    - match: \\\.[0-9A-Fa-f]{2}|\\:[0-9A-Fa-f]{4}
+    - match: |-
+        (?x)(
+          \\[0-7]{3}|
+          \\\.[0-9A-Fa-f]{2}|
+          \\:[0-9A-Fa-f]{4}
+        )
       scope: constant.character.encoding.wolfram
-    - match: \\\[\w+\]
+    - match: \\\[({{named_characters}})\]
       scope: constant.character.built-in.wolfram
 
-    # string template
+    # invalid characters
+    - match: |-
+        (?x)(
+          \\[0-7]{1,2}(?=[^0-7])|
+          \\\.[0-9A-Fa-f]?(?=[^0-9A-Fa-f])|
+          \\:[0-9A-Fa-f]{0,3}(?=[^0-9A-Fa-f])
+        )
+      scope: invalid.character.encoding.wolfram
+    - match: \\\[\w+\]
+      scope: invalid.character.built-in.wolfram
+    - match: \\[a-zA-Z]
+      scope: invalid.character.escape.wolfram
+
+  string:
+    - include: general-string
+    - match: '[\s\S]'
+      scope: string.quoted.wolfram
+
+  templated-string:
+    - include: general-string
     - match: \`\w*\`
       scope: variable.parameter.wolfram
     - match: <\*
@@ -149,7 +179,6 @@ contexts:
           pop: true
         - include: inside-string
         - include: expressions
-
     - match: '[\s\S]'
       scope: string.quoted.wolfram
 
@@ -158,6 +187,14 @@ contexts:
       captures:
         1: keyword.operator.MessageName.wolfram
         2: string.unquoted.wolfram
+      push:
+        - match: \s*(:?=)\s*(")
+          captures:
+            1: keyword.operator.assignment.wolfram
+            2: string.quoted.wolfram punctuation.definition.string.begin
+          push: templated-string
+        - match: (?=[\s\S])
+          pop: true
     # ENHANCEMENT: infix
     - match: (//)\s*({{identifier}})
       captures:
@@ -230,6 +267,21 @@ contexts:
         - include: expressions-nopattern
 
   function:
+    # string template functions
+    - match: ({{string_template_functions}})\s*(\[)(?=\s*")
+      captures:
+        1: variable.function.template.wolfram
+        2: punctuation.section.brackets.begin.wolfram
+      push:
+        - meta_scope: meta.block.wolfram
+        - match: \"
+          scope: string.quoted.wolfram punctuation.definition.string.begin
+          push: templated-string
+        - match: \]
+          scope: punctuation.section.brackets.end.wolfram
+          pop: true
+        - include: expressions
+
     - match: ({{identifier}})\s*(\[(?!\[))
       captures:
         1: variable.function.wolfram
@@ -240,19 +292,21 @@ contexts:
           scope: punctuation.section.brackets.end.wolfram
           pop: true
         - include: expressions
+
     - match: ({{identifier}})(?=\s*(@\*|@{1,3}|\/[@*]))
       scope: variable.function.wolfram
 
   variable:
     - match: '(?:System`)?({{built_in_functions}})'
-      scope: variable.function
+      scope: variable.function.wolfram
     - match: '{{identifier}}'
-      scope: variable.other
+      scope: variable.other.wolfram
     - match: (#[a-zA-Z][[:alnum:]]*|#\d*)
-      scope: variable.parameter
+      scope: variable.parameter.wolfram
 
   scoping:
-    - match: (Block|Module|With|Function)\s*(\[(?!\[))
+    # scoping functions
+    - match: ({{scoping_functions}})\s*(\[(?!\[))
       captures:
         1: variable.function.scoping.wolfram
         2: punctuation.section.brackets.begin.wolfram

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -53,6 +53,8 @@ variables:
 
   string_template_functions: StringTemplate|TemplateApply
 
+  character_class: alnum|alpha|ascii|blank|cntrl|digit|graph|lower|print|punct|space|upper|word|xdigit
+
   nb_code_styles: (Input)
 
 contexts:
@@ -119,10 +121,6 @@ contexts:
       push: string
 
   general-string:
-    - match: \"
-      scope: string.quoted.wolfram punctuation.definition.string.end
-      pop: true
-
     # box representation
     - match: \\!\\\(
       scope: keyword.operator.string-box.wolfram
@@ -162,11 +160,17 @@ contexts:
       scope: invalid.character.escape.wolfram
 
   string:
+    - match: \"
+      scope: string.quoted.wolfram punctuation.definition.string.end
+      pop: true
     - include: general-string
     - match: '[\s\S]'
       scope: string.quoted.wolfram
 
   templated-string:
+    - match: \"
+      scope: string.quoted.wolfram punctuation.definition.string.end
+      pop: true
     - include: general-string
     - match: \`\w*\`
       scope: variable.parameter.wolfram
@@ -180,6 +184,64 @@ contexts:
           pop: true
         - include: inside-string
         - include: expressions
+    - match: '[\s\S]'
+      scope: string.quoted.wolfram
+
+  regular-expression:
+    - match: \"
+      scope: string.quoted.wolfram punctuation.definition.string.end
+      pop: true
+    - include: inside-regular-expression
+
+  inside-regular-expression:
+    - match: (?=")
+      pop: true
+    - match: \\\\[dDsSwW]
+      scope: storage.class.character.regexp.wolfram
+    - match: (\[\^?\[)(:(?:{{character_class}}):)(\]\])
+      captures:
+        1: storage.class.character.regexp.wolfram
+        2: constant.other.class.regexp.wolfram
+        3: storage.class.character.regexp.wolfram
+    - match: \\\\g?[1-9]+
+      scope: storage.other.reference.regexp.wolfram
+    - match: \(\?-?[ims]\)
+      scope: storage.modifier.mode.regexp.wolfram
+    - match: \.
+      scope: keyword.other.any.regexp.wolfram
+    - match: ([$^]|\\\\[bB])
+      scope: keyword.control.anchors.regexp.wolfram
+    - match: \|
+      scope: keyword.operator.alternation.regexp.wolfram
+    - match: ([?+*]|{[0-9]*,[0-9]+}|{[0-9]+,[0-9]*})
+      scope: keyword.other.qualifier.regexp.wolfram
+    - match: \[\^?
+      scope: keyword.control.set.regexp.wolfram
+      push:
+        - meta_scope: meta.set.regexp.wolfram
+        - match: \]
+          scope: keyword.control.set.regexp.wolfram
+          pop: true
+        - match: (?=")
+          pop: true
+        - match: .-.
+          scope: constant.other.range.regexp.wolfram
+        - include: general-string
+        - match: '[\s\S]'
+          scope: string.quoted.wolfram
+    - match: (\()(\?([:=!]|<[=!]))?
+      captures:
+        1: keyword.control.group.regexp.wolfram
+        2: constant.character.assertion.regexp.wolfram
+      push:
+        - meta_scope: meta.group.regexp.wolfram
+        - match: \)
+          scope: keyword.control.group.regexp.wolfram
+          pop: true
+        - include: inside-regular-expression
+    - match: \\\\[\S]
+      scope: constant.character.escape.regexp.wolfram
+    - include: general-string
     - match: '[\s\S]'
       scope: string.quoted.wolfram
 
@@ -278,6 +340,21 @@ contexts:
         - match: \"
           scope: string.quoted.wolfram punctuation.definition.string.begin
           push: templated-string
+        - match: \]
+          scope: punctuation.section.brackets.end.wolfram
+          pop: true
+        - include: expressions
+
+    # regular expression function
+    - match: (RegularExpression)\s*(\[(?!\[))
+      captures:
+        1: variable.function.template.wolfram
+        2: punctuation.section.brackets.begin.wolfram
+      push:
+        - meta_scope: meta.block.wolfram
+        - match: \"
+          scope: string.quoted.wolfram punctuation.definition.string.begin
+          push: regular-expression
         - match: \]
           scope: punctuation.section.brackets.end.wolfram
           pop: true

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -119,6 +119,10 @@ contexts:
         # escape characters
         - match: \\([nrtb]|\r?\n)
           scope: constant.character.escape.wolfram
+        - match: \\:\w{4}
+          scope: constant.character.encoding.wolfram
+        - match: \\\[\w+\]
+          scope: constant.character.built-in.wolfram
 
         # string template
         - match: \`\w*\`

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -20,7 +20,7 @@
   11.11`
 (*^^^^^^ constant.numeric *)
   11.11`11.11
-(* ^^^^^^^^^^^ constant.numeric *)
+(*^^^^^^^^^^^ constant.numeric *)
 
 
 (* NUMERIC CONSTANTS *)
@@ -157,27 +157,27 @@
 (*          ^^ keyword.operator *)
 
   f[x_, OptionsPattern[]] := 2x
-(* ^ entity.name.function *)
-(*  ^ variable.parameter *)
+(*^ entity.name.function *)
+(* ^ variable.parameter *)
 (*      ^^^^^^^^^^^^^^ variable.function *)
 (*                        ^^ keyword.operator *)
 
   f[x_?TrueQ, y_ /; Negative[y]] := 2x /; y > 0
-(* ^ entity.name.function *)
-(*  ^ variable.parameter *)
+(*^ entity.name.function *)
+(* ^ variable.parameter *)
 (*    ^ keyword.operator *)
 (*               ^^ keyword.operator *)
 
   f[x_, s_] := 2x
-(* ^ entity.name.function *)
-(*  ^ variable.parameter *)
+(*^ entity.name.function *)
+(* ^ variable.parameter *)
 
   f[x_] := 2x
-(* ^ entity.name.function *)
-(*  ^ variable.parameter *)
+(*^ entity.name.function *)
+(* ^ variable.parameter *)
 
   f[x_] /; x > 0 := x
-(* ^ entity.name.function  *)
+(*^ entity.name.function  *)
 
   f[[]]
 
@@ -193,8 +193,9 @@
   "\[alpha]"
 (* ^^^^^^^^ constant.character.built-in.wolfram *)
 
-  "\:123456"
+  "\:123456\.7890"
 (* ^^^^^^ constant.character.encoding.wolfram *)
+(*         ^^^^ constant.character.encoding.wolfram *)
 
   foo::bar = "message"
 (*   ^^ keyword.operator.MessageName *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -190,6 +190,12 @@
 (*          ^^ string.quoted *)
 (*                     ^^^^^^^^^^^^^^^^^^^ string.quoted *)
 
+  "\[alpha]"
+(* ^^^^^^^^ constant.character.built-in.wolfram *)
+
+  "\:123456"
+(* ^^^^^^ constant.character.encoding.wolfram *)
+
   foo::bar = "message"
 (*   ^^ keyword.operator.MessageName *)
 (*     ^^^ string.unquoted *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -164,7 +164,7 @@
 
   f[x_?TrueQ, y_ /; Negative[y]] := 2x /; y > 0
 (*^ entity.name.function *)
-(* ^ variable.parameter *)
+(*  ^^ variable.parameter *)
 (*    ^ keyword.operator *)
 (*               ^^ keyword.operator *)
 
@@ -218,6 +218,10 @@
 (*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.wolfram *)
 (*           ^^^^^^^^^^^^^^^^^^^^^ comment.block.wolfram comment.block.wolfram *)
 
+(* ::Input:: *)
+(* ^^ punctuation.style.begin.wolfram *)
+(*   ^^^^^ constant.language.style.wolfram *)
+
 
 (* BRACKETS *)
 
@@ -246,10 +250,10 @@
 (*^^^^^ meta.box.wolfram *)
 (*   ^^ punctuation.section.box.end.wolfram *)
 
-  [[ ]]
-(*^^ punctuation.section.parts.begin.wolfram *)
-(*^^^^^ meta.parts.wolfram *)
-(*   ^^ punctuation.section.parts.end.wolfram *)
+  [ [ ]]
+(*^^^ punctuation.section.parts.begin.wolfram *)
+(*^^^^^^ meta.parts.wolfram *)
+(*    ^^ punctuation.section.parts.end.wolfram *)
 
 
 (* SCOPING *)
@@ -293,7 +297,3 @@
   comment 
   asd
  *)
-
-(* ::Input:: *)
-(* ^^ punctuation.style.begin.wolfram *)
-(*   ^^^^^ constant.language.style.wolfram *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -6,129 +6,129 @@
   Run tests by pressing `ctrl+shift+b` (or `cmd+b` on macOS), i.e. run the `build` command
 *)
 
+
 (* NUMBERS *)
 
-   11
-(* ^^ constant.numeric *)
-   .11
-(* ^^^ constant.numeric *)
-   11.
-(* ^^^ constant.numeric *)
-   11.11
-(* ^^^^^ constant.numeric *)
-   11.11`
-(* ^^^^^^ constant.numeric *)
-   11.11`11.11
+  11
+(*^^ constant.numeric *)
+  .11
+(*^^^ constant.numeric *)
+  11.
+(*^^^ constant.numeric *)
+  11.11
+(*^^^^^ constant.numeric *)
+  11.11`
+(*^^^^^^ constant.numeric *)
+  11.11`11.11
 (* ^^^^^^^^^^^ constant.numeric *)
+
 
 (* NUMERIC CONSTANTS *)
 
-   Catalan
-(* ^ constant.numeric *)
-   Pi
-(* ^ constant.numeric *)
+  Catalan
+(*^ constant.numeric *)
+  Pi
+(*^ constant.numeric *)
 
-(* LANGUAGE CONSTANTS *)
 
-   True
-(* ^^^^ constant.language *)
-   Left
-(* ^^^^ constant.language *)
+(*LANGUAGE CONSTANTS *)
+
+  True
+(*^^^^ constant.language *)
+  Left
+(*^^^^ constant.language *)
+
 
 (* OPERATORS *)
 
   +
-(*^ keyword.operator.arithmetic*)
+(*^ keyword.operator.arithmetic *)
   -
-(*^ keyword.operator.arithmetic*)
+(*^ keyword.operator.arithmetic *)
   /
-(*^ keyword.operator.arithmetic*)
+(*^ keyword.operator.arithmetic *)
   *
-(*^ keyword.operator.arithmetic*)
+(*^ keyword.operator.arithmetic *)
 
   !
-(*^ keyword.operator.logical*)
+(*^ keyword.operator.logical *)
   &&
-(*^^ keyword.operator.logical*)
+(*^^ keyword.operator.logical *)
   ||
-(*^^ keyword.operator.logical*)
-
+(*^^ keyword.operator.logical *)
   >
-(*^ keyword.operator.comparison*)
+(*^ keyword.operator.comparison *)
   <
-(*^ keyword.operator.comparison*)
+(*^ keyword.operator.comparison *)
   ==
-(*^^ keyword.operator.comparison*)
+(*^^ keyword.operator.comparison *)
   >=
-(*^^ keyword.operator.comparison*)
+(*^^ keyword.operator.comparison *)
   <=
-(*^^ keyword.operator.comparison*)
+(*^^ keyword.operator.comparison *)
   ===
-(*^^^ keyword.operator.comparison*)
+(*^^^ keyword.operator.comparison *)
   =!=
-(*^^^ keyword.operator.comparison*)
+(*^^^ keyword.operator.comparison *)
 
-   @
-(* ^ keyword.operator *)
-   @@
-(* ^^ keyword.operator *)
-   @@@
-(* ^^^ keyword.operator *)
-   @*
-(* ^^ keyword.operator *)
-   /*
-(* ^^ keyword.operator *)
-   /@
-(* ^^ keyword.operator *)
-   /;
-(* ^^ keyword.operator *)
-   //
-(* ^^ keyword.operator *)
-   /:
-(* ^^ keyword.operator *)
-   =
-(* ^ keyword.operator *)
-   :=
-(* ^^ keyword.operator *)
-   :>
-(* ^^ keyword.operator *)
-   ->
-(* ^^ keyword.operator *)
-   <->
-(* ^^^ keyword.operator *)
+  @
+(*^ keyword.operator *)
+  @@
+(*^^ keyword.operator *)
+  @@@
+(*^^^ keyword.operator *)
+  @*
+(*^^ keyword.operator *)
+  /*
+(*^^ keyword.operator *)
+  /@
+(*^^ keyword.operator *)
+  /;
+(*^^ keyword.operator *)
+  //
+(*^^ keyword.operator *)
+  /:
+(*^^ keyword.operator *)
+  =
+(*^ keyword.operator *)
+  :=
+(*^^ keyword.operator *)
+  :>
+(*^^ keyword.operator *)
+  ->
+(*^^ keyword.operator *)
+  <->
+(*^^^ keyword.operator *)
 
 (* VARIABLES *)
 
   f[x]
-(*^ variable.function*)
+(*^ variable.function *)
   foo$bar12
 (*^^^^^^^^^ variable.other *)
   $foo
 (*^^^^ variable.other *)
   my`context12`$foo
-(*^^^^ variable.other *)
+(*^^^^^^^^^^^^^^^^^ variable.other *)
 
   Plus
-(* ^ variable.function *)
+(*^ variable.function *)
   System`Plus
-(*     ^^^ variable.function *)
+(*^^^^^^^^^^^ variable.function *)
 
   Image[Red, Interleaving -> True]
 (*^^^^^ variable.function *)
-(*      ^ constant.language *) (* seems wrong to me *)
+(*     ^ punctuation.section.brackets.begin.wolfram *)
 (*           ^^^^^^^^^^^^ variable.function.wolfram *)
 (*                        ^^ keyword.operator *)
 
+
 (* PATTERNS *)
 
-  var_head  foo
-(*^^^^^^^^ meta.pattern.blank.wolfram variable.parameter.wolfram *)
-(*          ^ variable.other *)
-
-  var_head:foo
+  var_head: foo
 (*^^^^^^^^ meta.pattern.blank.wolfram variable.parameter.wolfram *)
 (*        ^ meta.pattern.blank.wolfram keyword.operator.Optional.wolfram *)
-(*         ^^^ variable.other *)
+(*          ^^^ variable.other *)
 
   var_head ? EvenQ
 (*^^^^^^^^ meta.pattern.blank.wolfram variable.parameter.wolfram *)
@@ -138,7 +138,7 @@
   var: patt ? EvenQ : foo
 (*^^^ variable.parameter.wolfram *)
 (*   ^ keyword.operator.Pattern.wolfram *)
-(*      ^^^ meta.pattern.wolfram variable.other *)
+(*     ^^^ meta.pattern.wolfram variable.other *)
 (*          ^ meta.pattern.wolfram keyword.operator.PatternTest.wolfram *)
 (*            ^^^^^ meta.pattern.wolfram variable.function *)
 (*                  ^ keyword.operator.Optional.wolfram *)
@@ -148,110 +148,113 @@
 (* FUNCTIONS *)
 
   f[x_, y_] := 2x
-(*^ entity.name.function*)
+(*^ entity.name.function *)
 (* ^ meta.arguments.wolfram punctuation.section.brackets.begin.wolfram *)
 (*  ^^ meta.arguments.wolfram meta.pattern.blank.wolfram variable.parameter.wolfram *)
 (*    ^^ meta.arguments.wolfram punctuation.separator.sequence.wolfram *)
-(*      ^ variable.parameter*)
+(*      ^ variable.parameter *)
 (*        ^ meta.arguments.wolfram punctuation.section.brackets.end.wolfram *)
-(*          ^^ keyword.operator*)
+(*          ^^ keyword.operator *)
 
   f[x_, OptionsPattern[]] := 2x
-(*^ entity.name.function*)
-(*  ^ variable.parameter*)
-(*      ^^^^^^^^^^^^^^ variable.function*)
-(*                        ^^ keyword.operator*)
+(* ^ entity.name.function *)
+(*  ^ variable.parameter *)
+(*      ^^^^^^^^^^^^^^ variable.function *)
+(*                        ^^ keyword.operator *)
 
   f[x_?TrueQ, y_ /; Negative[y]] := 2x /; y > 0
-(*^ entity.name.function*)
-(*  ^ variable.parameter*)
-(*    ^ keyword.operator*)
-(*               ^^ keyword.operator*)
-
+(* ^ entity.name.function *)
+(*  ^ variable.parameter *)
+(*    ^ keyword.operator *)
+(*               ^^ keyword.operator *)
 
   f[x_, s_] := 2x
-(*^ entity.name.function*)
-(*  ^ variable.parameter*)
+(* ^ entity.name.function *)
+(*  ^ variable.parameter *)
 
   f[x_] := 2x
-(*^ entity.name.function*)
-(*  ^ variable.parameter*)
+(* ^ entity.name.function *)
+(*  ^ variable.parameter *)
 
   f[x_] /; x > 0 := x
-(*^ entity.name.function  *)
+(* ^ entity.name.function  *)
 
   f[[]]
 
 
 (* STRINGS *)
 
-  "This is a `string` (* this is not \a comment*)"
-(* ^ string.quoted *)
-(*            ^ constant.other.placeholder *)
-(*                       ^ string.quoted *)
-(*                                    ^ constant.character.escape *)
+  "This is\n\a string. (* not a comment *)"
+(*^ punctualation.defination.string.begin *)
+(*        ^^ constant.character.escape *)
+(*          ^^ string.quoted *)
 
   foo::bar = "message"
 (*   ^^ keyword.operator.MessageName *)
 (*     ^^^ string.unquoted *)
-(*             ^^ string.quoted *)
+(*           ^^^^^^^^^ string.quoted *)
 
-  "this`is`a`context"
-(*^ punctuation.definition.string.begin *)
-(* ^^^^^^^^^^^^^^^^^ string.quoted.wolfram*)
+  StringTemplate["Value `a`: <* Range[#n] *>."][<|"a" -> 1234, "n" -> 3|>]
+(*                      ^^^ variable.parameter *)
+(*                           ^^ keyword.operator.template-expression *)
+
+  "box 1: \!\(x\^2\); box 2: \(y\^3\) "
+(*        ^ keyword.operator.string-box *)
+(*             ^^ keyword.operator.x-scriptBox *)
 
 
 (* COMMENTS *)
 
-(* simple comment *)
-(* ^ comment.block *)
-
-(* comment (*in a comment*) *)
-(* ^^^^^^^^ comment.block.wolfram *)
-(*         ^^^^^^^^^^^^^^^^ comment.block.wolfram comment.block.wolfram *)
+  (* comment (* another comment *) *)
+(*^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.wolfram *)
+(*           ^^^^^^^^^^^^^^^^^^^^^ comment.block.wolfram comment.block.wolfram *)
 
 
 (* BRACKETS *)
 
-  <|   |>  foo
-(*^^ meta.association.wolfram punctuation.section.association.begin.wolfram  *)
-(*   ^ meta.association.wolfram  *)
-(*     ^^ meta.association.wolfram punctuation.section.association.end.wolfram *)
-(*         ^^^ source.wolfram variable.other *)
+  <| |>
+(*^^ punctuation.section.association.begin.wolfram  *)
+(*^^^^^ meta.association.wolfram  *)
+(*   ^^ punctuation.section.association.end.wolfram *)
 
   [ ]
-(*^ meta.brackets.wolfram punctuation.section.brackets.begin.wolfram *)
-(* ^ meta.brackets.wolfram *)
-(*  ^ meta.brackets.wolfram punctuation.section.brackets.end.wolfram *)
+(*^ punctuation.section.brackets.begin.wolfram *)
+(*^^^ meta.brackets.wolfram *)
+(*  ^ punctuation.section.brackets.end.wolfram *)
 
   { }
-(*^ meta.braces.wolfram punctuation.section.braces.begin.wolfram *)
-(* ^ meta.braces.wolfram *)
-(*  ^ meta.braces.wolfram punctuation.section.braces.end.wolfram *)
+(*^ punctuation.section.braces.begin.wolfram *)
+(*^^^ meta.braces.wolfram *)
+(*  ^ punctuation.section.braces.end.wolfram *)
 
   ( )
-(*^ meta.parens.wolfram punctuation.section.parens.begin.wolfram *)
-(* ^ meta.parens.wolfram *)
-(*  ^ meta.parens.wolfram punctuation.section.parens.end.wolfram *)
+(*^ punctuation.section.parens.begin.wolfram *)
+(*^^^ meta.parens.wolfram *)
+(*  ^ punctuation.section.parens.end.wolfram *)
 
-  [ [ ]]
-(*^^^ meta.parts.wolfram punctuation.section.parts.begin.wolfram *)
-(*   ^ meta.parts.wolfram *)
-(*    ^^ meta.parts.wolfram punctuation.section.parts.end.wolfram *)
+  \( \)
+(*^^ punctuation.section.box.begin.wolfram *)
+(*^^^^^ meta.box.wolfram *)
+(*   ^^ punctuation.section.box.end.wolfram *)
+
+  [[ ]]
+(*^^ punctuation.section.parts.begin.wolfram *)
+(*^^^^^ meta.parts.wolfram *)
+(*   ^^ punctuation.section.parts.end.wolfram *)
 
 
 (* SCOPING *)
 
-Module[
-(*^^^^ variable.function.scoping.wolfram *)
-(*    ^ punctuation.section.brackets.begin.wolfram *)
+  Module[
+(*^^^^^^ variable.function.scoping.wolfram *)
+(*      ^ punctuation.section.brackets.begin.wolfram *)
     { foo, bar = 1},
 (*   ^ meta.block.local.wolfram *)
 (*    ^^^ meta.block.local.wolfram variable.parameter.wolfram *)
-(*                  ^ meta.block.wolfram *)
+(*                 ^ meta.block.wolfram *)
     foo
 (*  ^^^ meta.block.wolfram variable.other *)
-]
+  ]
 
 Block[
   {
@@ -260,11 +263,11 @@ Block[
 (*        ^^^^^^^^^^^ meta.block.local.wolfram comment.block.wolfram *)
 (*                    ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
 (*                           ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
-(*                                  ^^^^ meta.block.local.wolfram variable.other*)
+(*                                  ^^^^ meta.block.local.wolfram variable.other *)
   },
 
   code
-(*^^^^ meta.block.wolfram variable.other *)
+(* ^^^^ meta.block.wolfram variable.other *)
 
 ]
 
@@ -281,6 +284,6 @@ Block[
 (* multiline (* also a comment *)
   comment 
   asd
-*)
+ *)
 
 (* ::s:: *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -185,7 +185,7 @@
 (* STRINGS *)
 
   "This is\n\a string. (* not a comment *)"
-(*^ punctualation.defination.string.begin *)
+(*^ punctuation.definition.string.begin *)
 (*        ^^ constant.character.escape *)
 (*          ^^ string.quoted *)
 (*                     ^^^^^^^^^^^^^^^^^^^ string.quoted *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -187,15 +187,22 @@
   "This is\n\a string. (* not a comment *)"
 (*^ punctuation.definition.string.begin *)
 (*        ^^ constant.character.escape *)
-(*          ^^ string.quoted *)
+(*          ^^ invalid.character.escape *)
 (*                     ^^^^^^^^^^^^^^^^^^^ string.quoted *)
 
-  "\[alpha]"
+  "\[Alpha] \[alpha]"
 (* ^^^^^^^^ constant.character.built-in.wolfram *)
+(*          ^^^^^^^^ invalid.character.built-in.wolfram *)
 
-  "\:123456\.7890"
+  "\:123456\.7890\12345"
 (* ^^^^^^ constant.character.encoding.wolfram *)
 (*         ^^^^ constant.character.encoding.wolfram *)
+(*               ^^^^ constant.character.encoding.wolfram *)
+
+  "\:1 \.2 \34"
+(* ^^^ invalid.character.encoding.wolfram *)
+(*     ^^^ invalid.character.encoding.wolfram *)
+(*         ^^^ invalid.character.encoding.wolfram *)
 
   foo::bar = "message"
 (*   ^^ keyword.operator.MessageName *)
@@ -209,7 +216,7 @@
   "box 1: \!\(x\^2\); box 2: \(y\^3\) "
 (*        ^ keyword.operator.string-box *)
 (*             ^^ keyword.operator.x-scriptBox *)
-(*                           ^^^^^^^^ string.quoted *)
+(*                           ^^ constant.character.escape.wolfram *)
 
 
 (* COMMENTS *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -218,6 +218,34 @@
 (*             ^^ keyword.operator.x-scriptBox *)
 (*                           ^^ constant.character.escape.wolfram *)
 
+  RegularExpression["^a\n.+?\\^[^a-f*]{2,}"]
+(*                   ^ keyword.control.anchors.regexp *)
+(*                    ^ string.quoted *)
+(*                     ^^ constant.character.escape *)
+(*                       ^ keyword.other.any.regexp *)
+(*                        ^^ keyword.other.qualifier.regexp *)
+(*                          ^^^ constant.character.escape.regexp  *)
+(*                             ^^^^^^^ meta.set.regexp *)
+(*                             ^^ keyword.control.set.regexp *)
+(*                               ^^^ constant.other.range.regexp *)
+(*                                  ^ string.quoted *)
+(*                                   ^ keyword.control.set.regexp *)
+(*                                    ^^^^ keyword.other.qualifier.regexp *)
+
+  RegularExpression["(?=[^[:alpha:]](\\d*))\\g1\\2"]
+(*                   ^^^^^^^^^^^^^^^^^^^^^^ meta.group.regexp *)
+(*                   ^ keyword.control.group.regexp *)
+(*                    ^^ constant.character.assertion.regexp *)
+(*                      ^^^ storage.class.character.regexp *)
+(*                         ^^^^^^^ constant.other.class.regexp *)
+(*                                ^^ storage.class.character.regexp *)
+(*                                  ^^^^^^ meta.group.regexp *)
+(*                                  ^ keyword.control.group.regexp *)
+(*                                   ^^^ storage.class.character.regexp *)
+(*                                      ^ keyword.other.qualifier.regexp *)
+(*                                       ^^ keyword.control.group.regexp *)
+(*                                         ^^^^^^^ storage.other.reference.regexp *)
+
 
 (* COMMENTS *)
 

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -188,6 +188,7 @@
 (*^ punctualation.defination.string.begin *)
 (*        ^^ constant.character.escape *)
 (*          ^^ string.quoted *)
+(*                     ^^^^^^^^^^^^^^^^^^^ string.quoted *)
 
   foo::bar = "message"
 (*   ^^ keyword.operator.MessageName *)
@@ -201,6 +202,7 @@
   "box 1: \!\(x\^2\); box 2: \(y\^3\) "
 (*        ^ keyword.operator.string-box *)
 (*             ^^ keyword.operator.x-scriptBox *)
+(*                           ^^^^^^^^ string.quoted *)
 
 
 (* COMMENTS *)
@@ -256,20 +258,19 @@
 (*  ^^^ meta.block.wolfram variable.other *)
   ]
 
-Block[
-  {
-    var1, (*comment*) var2 , var3 = var4
-(*  ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
-(*        ^^^^^^^^^^^ meta.block.local.wolfram comment.block.wolfram *)
-(*                    ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
-(*                           ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
-(*                                  ^^^^ meta.block.local.wolfram variable.other *)
-  },
+  Block[
+    {
+      var1, (*comment*) var2, var3 = var4
+(*    ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
+(*          ^^^^^^^^^^^ meta.block.local.wolfram comment.block.wolfram *)
+(*                      ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
+(*                            ^^^^ meta.block.local.wolfram variable.parameter.wolfram *)
+(*                                   ^^^^ meta.block.local.wolfram variable.other *)
+    },
 
-  code
-(* ^^^^ meta.block.wolfram variable.other *)
-
-]
+    code
+(*  ^^^^ meta.block.wolfram variable.other *)
+  ]
 
 
 (* ASSERTION FREE *)
@@ -286,4 +287,6 @@ Block[
   asd
  *)
 
-(* ::s:: *)
+(* ::Input:: *)
+(* ^^ punctuation.style.begin.wolfram *)
+(*   ^^^^^ constant.language.style.wolfram *)


### PR DESCRIPTION
#### Support built-in characters and character encoding in strings.
```mathematica
  "\[alpha]"
(* ^^^^^^^^ constant.character.built-in.wolfram *)

  "\:123456"
(* ^^^^^^ constant.character.encoding.wolfram *)
```
---
#### Not treat `\` as escape anymore, but special characters like `\n` will be recognized as escapes as usual.
```mathematica
  "This is\n\a string. (* not a comment *)"
(*^ punctualation.defination.string.begin *)
(*        ^^ constant.character.escape *)
(*          ^^ string.quoted *)
```
---
#### Support [string templates](https://reference.wolfram.com/language/ref/StringTemplate.html).
```mathematica
  StringTemplate["Value `a`: <* Range[#n] *>."][<|"a" -> 1234, "n" -> 3|>]
(*                      ^^^ variable.parameter *)
(*                           ^^ keyword.operator.template-expression *)
```
---
#### Support [string representation of boxes](https://reference.wolfram.com/language/tutorial/StringRepresentationOfBoxes.html).
```mathematica
  "box 1: \!\(x\^2\); box 2: \(y\^3\) "
(*        ^ keyword.operator.string-box *)
(*             ^^ keyword.operator.x-scriptBox *)
(*                           ^^^^^^^^ string.quoted *)

  \( \)
(*^^ punctuation.section.box.begin.wolfram *)
(*^^^^^ meta.box.wolfram *)
(*   ^^ punctuation.section.box.end.wolfram *)
```
