### PR TITLE
Operater optimization

### DIFF
--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -19,8 +19,9 @@ scope: source.wolfram
 # Partly based on https://github.com/JuliaEditorSupport/Julia-sublime/blob/master/Julia.sublime-syntax
 
 variables:
+  number: (?:\d+\.?|\.\d)\d*
   symbol: '[$[:alpha:]]+[$[:alnum:]]*'
-  identifier: (?:{{symbol}}`)*({{symbol}})
+  identifier: (?:{{symbol}}`)*{{symbol}}
 
   # Built-in functions
   built_in_functions: |-
@@ -90,14 +91,19 @@ contexts:
         pop: true
 
   literals:
-    - match: (?:\d+\.?|\.\d)\d*\`{0,2}
+    # numbers, with base, scientific notation, precision or accuracy
+    - match: ([0-9]+\^\^)?{{number}}(\`\`?{{number}})?(\*\^{{number}})?
       scope: constant.numeric.wolfram
+
+    # built-in symbols
     - match: ((?:System`)?{{built_in_numeric_constants}})
       scope: constant.numeric.wolfram
     - match: ((?:System`)?{{built_in_constants}})
       scope: constant.language.wolfram
     - match: ((?:System`)?{{built_in_options}})
       scope: variable.function.wolfram
+
+    # strings
     - match: \"
       scope: punctuation.definition.string.begin
       push:
@@ -115,6 +121,8 @@ contexts:
           scope: constant.other.placeholder.wolfram
 
   shorthand:
+    - match: '%(\d*|%*)'
+      scope: storage.type.Out.wolfram
     - match: (::)\s*([[:alnum:]]+)
       captures:
         1: keyword.operator.MessageName.wolfram
@@ -136,9 +144,9 @@ contexts:
       scope: keyword.operator.logical.wolfram
     - match: (:?=|\/:|[-:]>|[+\-*/]=|<->)
       scope: keyword.operator.assignment.wolfram
-    - match: '\/;'
+    - match: \/;
       scope: keyword.operator.condition.wolfram
-    - match: (\+\+|--|[+\-*/])
+    - match: (\+\+|--|[+\-*/^])
       scope: keyword.operator.arithmetic.wolfram
     - match: (>>>?|<<<?)
       scope: keyword.operator.flow.wolfram
@@ -146,14 +154,14 @@ contexts:
       scope: keyword.operator.string.wolfram
     - match: \.\.\.?
       scope: keyword.operator.repeat.wolfram
-    - match: ';;'
+    - match: ;;
       scope: keyword.operator.span.wolfram
-    - match: ';'
+    - match: ;
       scope: keyword.operator.compound.wolfram
     - match: \\\[[[:alnum:]]+\]
       scope: keyword.operator.word.wolfram
     - match: '&'
-      scope: keyword.operator.function.wolfram
+      scope: keyword.operator.function variable.function.wolfram
 
   pattern-short:
     # Including Blank, BlankSequence, BlankNullSequence
@@ -278,8 +286,10 @@ contexts:
             - include: sequence
         - match: (?=[^\[])
           pop: true
-    - match: ((?:{{symbol}}`)*(\${{symbol}}))(?=\s*:?=)
-      scope: entity.name.constant.wolfram
+    # - match: ((?:{{symbol}}`)*(\${{symbol}}))(?=\s*:?=)
+    #   scope: entity.name.constant.wolfram
+    - match: ({{identifier}})(?=\s*:?=\s*Function\s*\[(?!\s*\[))
+      scope: entity.name.function.wolfram
 
   sequence:
     - meta_scope: meta.sequence.wolfram

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -219,17 +219,17 @@ contexts:
         (?x)
         ({{identifier}})?
         (?:
+          (_\.)               # Default
+          |
           (_{1,3})            # Blank, BlankSequence, BlankNullSequence
           ({{identifier}})?   # Head
-          |
-          (_\.)               # Default
         )
       scope: meta.parameter.wolfram
       captures:
         1: variable.parameter.wolfram
-        2: variable.parameter.blank.wolfram
-        3: variable.parameter.head.wolfram
-        4: variable.parameter.default.wolfram
+        2: variable.parameter.default.wolfram
+        3: variable.parameter.blank.wolfram
+        4: variable.parameter.head.wolfram
       push:
         - match: (?:\s*)(\?)                          # PatternTest
           scope: meta.pattern.wolfram

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -47,25 +47,7 @@ variables:
       Catalan|Degree|E|EulerGamma|Glaisher|GoldenAngle|GoldenRatio|I|Khinchin|MachinePrecision|Pi
     )\b
 
-  first_param_functional_functions: |-
-    (?x)
-    Apply|ArrayFilter|
-    BlockMap|
-    FixedPoint|FixedPointList|Fold|FoldList|FoldPair|FoldPairList|
-    Map|MapAt|MapIndexed|MapThread|
-    Nest|NestList|NestGraph|NestWhile|NestWhileList|
-    Scan|SequenceFold|SequenceFoldList
-
-  last_param_functional_functions: |-
-    (?x)
-    CountDistinctBy|LengthWhile|TakeWhile
-
-  parametic_functions: Table|Do|Sum|Product
-
-  scoping_functions: Block|Module|With|Function
-
-  nb_code_styles: (Input)
-
+  scoping_functions: Block|Module|With|Function|DynamicModule
 
 contexts:
 
@@ -82,7 +64,6 @@ contexts:
     - include: literals
     - include: shorthand
     - include: operators
-    - include: pattern-short
     - include: function
     - include: variable
     - include: nested
@@ -215,29 +196,11 @@ contexts:
     - match: \?\??
       scope: keyword.operator.definition.wolfram
 
-  pattern-short:
-    # support Blank, BlankSequence, BlankNullSequence
-    # can also be matched with Pattern, PatternTest, Optional
-    - match: ({{identifier}})?(_{1,3})(({{identifier}})?)
-      scope: variable.parameter.wolfram
-      push:
-        - meta_scope: meta.pattern.blank.wolfram
-        - match: (?:\s*)(\?)
-          captures:
-            1: keyword.operator.PatternTest.wolfram
-          pop: true
-        - match: (?:\s*)(:)(?=[^:>=])
-          captures:
-            1: keyword.operator.Optional.wolfram
-          pop: true
-        - match: (?=.)
-          pop: true
-
   pattern:
     - match: ({{identifier}})\s*(:(?=[^:>=]))
       captures:
         1: variable.parameter.wolfram
-        3: keyword.operator.Pattern.wolfram
+        2: keyword.operator.Pattern.wolfram
       push:
         - meta_content_scope: meta.pattern.wolfram
         - match: \?
@@ -251,26 +214,47 @@ contexts:
         - include: expressions-nopattern
 
   variable:
+    # parameters
+    - match: |-
+        (?x)
+        ({{identifier}})?
+        (?:
+          (_{1,3})            # Blank, BlankSequence, BlankNullSequence
+          ({{identifier}})?   # Head
+          |
+          (_\.)               # Default
+        )
+      scope: meta.parameter.wolfram
+      captures:
+        1: variable.parameter.wolfram
+        2: variable.parameter.blank.wolfram
+        3: variable.parameter.head.wolfram
+        4: variable.parameter.default.wolfram
+      push:
+        - match: (?:\s*)(\?)                          # PatternTest
+          scope: meta.pattern.wolfram
+          captures:
+            1: keyword.operator.PatternTest.wolfram
+          pop: true
+        - match: (?:\s*)(:)(?=[^:>=])                 # Optional
+          scope: meta.pattern.wolfram
+          captures:
+            1: keyword.operator.Optional.wolfram
+          pop: true
+        - match: (?=.)
+          pop: true
+    
+    # variables
     - match: (?:System`)?({{built_in_functions}})
       scope: variable.function
     - match: '{{identifier}}'
       scope: variable.other
+
+    # slots
     - match: (#[a-zA-Z][[:alnum:]]*|#\d*)
       scope: variable.parameter
 
   function:
-    # parametic functions
-    - match: ({{parametic_functions}})\s*(\[(?!\[))
-      captures:
-        1: variable.function.parametic.wolfram
-        2: punctuation.section.brackets.begin.wolfram
-      push:
-        - meta_content_scope: meta.block.wolfram
-        - match: ','
-          scope: punctuation.separator.sequence.wolfram
-          push: parameter
-        - include: meta-block
-
     # scoping functions
     - match: ({{scoping_functions}})\s*(\[(?!\[))
       captures:
@@ -283,26 +267,6 @@ contexts:
           set: [localized, local]
         - include: meta-block
 
-    # functional functions
-    - match: ({{first_param_functional_functions}})\s*(\[)\s*({{identifier}})
-      captures:
-        1: variable.function.scoping.wolfram
-        2: punctuation.section.brackets.begin.wolfram
-        3: variable.function.wolfram
-      push: meta-block
-    - match: ({{last_param_functional_functions}})\s*(\[(?!\[))
-      captures:
-        1: variable.function.scoping.wolfram
-        2: punctuation.section.brackets.begin.wolfram
-      push:
-        - meta_content_scope: meta.block.wolfram
-        - match: ({{identifier}})\s*\]
-          captures:
-            1: variable.function.wolfram
-            2: punctuation.section.brackets.end.wolfram
-          pop: true
-        - include: meta-block
-
     # general functions
     - match: ({{identifier}})\s*(\[(?!\[))
       captures:
@@ -311,15 +275,6 @@ contexts:
       push: meta-block
     - match: ({{identifier}})\s*(?=@{1,3}|//?@)
       scope: variable.function.wolfram
-
-  parameter:
-    - match: (\{)\s*({{symbol}})
-      captures:
-        1: punctuation.section.braces.begin.wolfram
-        2: variable.parameter.wolfram
-      push: meta-parameter
-    - match: (?=\S)
-      pop: true
 
   localized:
     - meta_content_scope: meta.block.local.wolfram
@@ -346,7 +301,6 @@ contexts:
     - match: (?=[\,|\}])
       pop: true
     - include: expressions
-
 
   declarations:
     - match: |-

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -48,16 +48,33 @@ variables:
       Catalan|Degree|E|EulerGamma|Glaisher|GoldenAngle|GoldenRatio|I|Khinchin|MachinePrecision|Pi
     )\b
 
+  first_param_functional_functions: |-
+    (?x)
+    Apply|ArrayFilter|
+    BlockMap|
+    FixedPoint|FixedPointList|Fold|FoldList|FoldPair|FoldPairList|
+    Map|MapAt|MapIndexed|MapThread|
+    Nest|NestList|NestGraph|NestWhile|NestWhileList|
+    Scan|SequenceFold|SequenceFoldList
+
+  last_param_functional_functions: |-
+    (?x)
+    CountDistinctBy|LengthWhile|TakeWhile
+
+  parametic_functions: Table|Do|Sum|Product
+
+  scoping_functions: Block|Module|With|Function
+
   nb_code_styles: (Input)
 
 
 contexts:
 
   main:
-    - include: declarations
     - include: expressions
 
   expressions:
+    - include: declarations
     - include: pattern
     - include: expressions-nopattern
 
@@ -67,13 +84,12 @@ contexts:
     - include: shorthand
     - include: operators
     - include: pattern-short
-    - include: scoping
     - include: function
     - include: variable
     - include: nested
 
   comments:
-    - match: '(\(\*\s*)(::)([[:alnum:]]+)(::)(\s*\*\))'
+    - match: (\(\*\s*)(::)([[:alnum:]]+)(::)(\s*\*\))
       captures:
         1: comment.line.wolfram
         2: constant.numeric.line-number.find-in-files
@@ -92,7 +108,7 @@ contexts:
 
   literals:
     # numbers, with base, scientific notation, precision or accuracy
-    - match: ([0-9]+\^\^)?{{number}}(\`\`?{{number}})?(\*\^{{number}})?
+    - match: ([0-9]+\^\^)?{{number}}(\`\`?({{number}})?)?(\*\^{{number}})?
       scope: constant.numeric.wolfram
 
     # built-in symbols
@@ -101,7 +117,7 @@ contexts:
     - match: ((?:System`)?{{built_in_constants}})
       scope: constant.language.wolfram
     - match: ((?:System`)?{{built_in_options}})
-      scope: variable.function.wolfram
+      scope: variable.parameter.wolfram
 
     # strings
     - match: \"
@@ -121,17 +137,33 @@ contexts:
           scope: constant.other.placeholder.wolfram
 
   shorthand:
+    # Out
     - match: '%(\d*|%*)'
       scope: storage.type.Out.wolfram
+
+    # MessageName
     - match: (::)\s*([[:alnum:]]+)
       captures:
         1: keyword.operator.MessageName.wolfram
         2: string.unquoted.wolfram
-    # ENHANCEMENT: infix
-    - match: (//)\s*({{identifier}})
+
+    # Infix
+    - match: ~
+      scope: keyword.operator.call.wolfram
+      push:
+        - meta_content_scope: meta.infix.wolfram
+        - match: ({{identifier}})?\s*(~)
+          captures:
+            1: variable.function.wolfram
+            2: keyword.operator.call.wolfram
+          pop: true
+        - include: expressions
+
+    # Postfix and compound functions
+    - match: (//|@\*)\s*({{identifier}})
       captures:
-        1: keyword.operator.Postfix.wolfram
-        3: variable.function.wolfram
+        1: keyword.operator.call.wolfram
+        2: variable.function.wolfram
 
   operators:
     - match: (@\*|@{1,3}|\/[@*])
@@ -162,10 +194,12 @@ contexts:
       scope: keyword.operator.word.wolfram
     - match: '&'
       scope: keyword.operator.function variable.function.wolfram
+    - match: \?\??
+      scope: keyword.operator.definition.wolfram
 
   pattern-short:
-    # Including Blank, BlankSequence, BlankNullSequence
-    # Can also be matched with Pattern, PatternTest, Optional
+    # support Blank, BlankSequence, BlankNullSequence
+    # can also be matched with Pattern, PatternTest, Optional
     - match: ({{identifier}})?(_{1,3})(({{identifier}})?)
       scope: variable.parameter.wolfram
       push:
@@ -182,7 +216,7 @@ contexts:
           pop: true
 
   pattern:
-    - match: '({{identifier}})\s*(:(?=[^:>=]))'
+    - match: ({{identifier}})\s*(:(?=[^:>=]))
       captures:
         1: variable.parameter.wolfram
         3: keyword.operator.Pattern.wolfram
@@ -190,7 +224,7 @@ contexts:
         - meta_content_scope: meta.pattern.wolfram
         - match: \?
           scope: keyword.operator.PatternTest.wolfram
-        - match: ':(?=[^:>=])'
+        - match: :(?=[^:>=])
           scope: keyword.operator.Optional.wolfram
           pop: true
         # we should check the precedence here
@@ -198,54 +232,92 @@ contexts:
           pop: true
         - include: expressions-nopattern
 
-  function:
-    - match: ({{identifier}})\s*(\[(?!\[))
-      captures:
-        1: variable.function.wolfram
-        3: punctuation.section.brackets.begin.wolfram
-      push: 
-        - meta_scope: meta.block.wolfram
-        - match: \]
-          scope: punctuation.section.brackets.end.wolfram
-          pop: true
-        - include: expressions
-    - match: ({{identifier}})(?=\s*(@\*|@{1,3}|\/[@*]))
-      scope: variable.function.wolfram
-
   variable:
-    - match: '(?:System`)?({{built_in_functions}})'
+    - match: (?:System`)?({{built_in_functions}})
       scope: variable.function
     - match: '{{identifier}}'
       scope: variable.other
     - match: (#[a-zA-Z][[:alnum:]]*|#\d*)
       scope: variable.parameter
 
-  scoping:
-    - match: (Block|Module|With|Function)\s*(\[(?!\[))
+  function:
+    # parametic functions
+    - match: ({{parametic_functions}})\s*(\[(?!\[))
+      captures:
+        1: variable.function.parametic.wolfram
+        2: punctuation.section.brackets.begin.wolfram
+      push:
+        - meta_content_scope: meta.block.wolfram
+        - match: ','
+          scope: punctuation.separator.sequence.wolfram
+          push: parameter
+        - include: meta-block
+
+    # scoping functions
+    - match: ({{scoping_functions}})\s*(\[(?!\[))
       captures:
         1: variable.function.scoping.wolfram
         2: punctuation.section.brackets.begin.wolfram
       push:
         - meta_content_scope: meta.block.wolfram
-        - match: '\{'
+        - match: \{
+          scope: punctuation.section.braces.begin.wolfram
           set: [localized, local]
-        - match: '\]'
-          scope: punctuation.section.brackets.end.wolfram
+        - include: meta-block
+
+    # functional functions
+    - match: ({{first_param_functional_functions}})\s*(\[)\s*({{identifier}})
+      captures:
+        1: variable.function.scoping.wolfram
+        2: punctuation.section.brackets.begin.wolfram
+        3: variable.function.wolfram
+      push: meta-block
+    - match: ({{last_param_functional_functions}})\s*(\[(?!\[))
+      captures:
+        1: variable.function.scoping.wolfram
+        2: punctuation.section.brackets.begin.wolfram
+      push:
+        - meta_content_scope: meta.block.wolfram
+        - match: ({{identifier}})\s*\]
+          captures:
+            1: variable.function.wolfram
+            2: punctuation.section.brackets.end.wolfram
           pop: true
-        - include: expressions
+        - include: meta-block
+
+    # general functions
+    - match: ({{identifier}})\s*(\[(?!\[))
+      captures:
+        1: variable.function.wolfram
+        3: punctuation.section.brackets.begin.wolfram
+      push: meta-block
+    - match: ({{identifier}})\s*(?=@{1,3}|//?@)
+      scope: variable.function.wolfram
+
+  parameter:
+    - match: (\{)\s*({{symbol}})
+      captures:
+        1: punctuation.section.braces.begin.wolfram
+        2: variable.parameter.wolfram
+      push: meta-parameter
+    - match: (?=[\s\S])
+      pop: true
 
   localized:
     - meta_content_scope: meta.block.local.wolfram
-    - match: '\,'
+    - match: ','
+      scope: punctuation.separator.sequence.wolfram
       push: local
-    - match: '\}'
+    - match: \}
+      scope: punctuation.section.braces.end.wolfram
       set:
         - meta_content_scope: meta.block.wolfram
-        - match: '\]'
+        - match: \]
           scope: punctuation.section.brackets.end.wolfram
           pop: true
         - include: expressions
-    - match: '\]'
+    - match: \]
+      scope: punctuation.section.brackets.end.wolfram
       pop: true
     - include: expressions
 
@@ -288,6 +360,18 @@ contexts:
           pop: true
     # - match: ((?:{{symbol}}`)*(\${{symbol}}))(?=\s*:?=)
     #   scope: entity.name.constant.wolfram
+    - match: |-
+        (?x)
+        {{identifier}}
+        (?=
+          \s*:?=\s*
+          (
+            [^\(\)]+|
+            \((?>\g<-1>)*\)
+          )*
+          &(;|$)
+        )
+      scope: entity.name.function.wolfram
     - match: ({{identifier}})(?=\s*:?=\s*Function\s*\[(?!\s*\[))
       scope: entity.name.function.wolfram
 
@@ -340,3 +424,17 @@ contexts:
           scope: punctuation.section.association.end.wolfram
           pop: true
         - include: expressions
+
+  meta-block:
+    - meta_scope: meta.block.wolfram
+    - match: \]
+      scope: punctuation.section.brackets.end.wolfram
+      pop: true
+    - include: expressions
+
+  meta-parameter:
+    - meta_scope: meta.parameter.wolfram
+    - match: \}
+      scope: punctuation.section.braces.end.wolfram
+      pop: true
+    - include: expressions

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -10,7 +10,6 @@ file_extensions:
   - m
   - wl
   - wls
-  # FIXME: special process when rendering .nb file
   - nb
 
 first_line_match: ^#!.*\b(math|wolfram).*$
@@ -160,7 +159,7 @@ contexts:
         - include: expressions
 
     # Postfix and compound functions
-    - match: (//|@\*)\s*({{identifier}})
+    - match: (//|[@/]\*)\s*({{identifier}})
       captures:
         1: keyword.operator.call.wolfram
         2: variable.function.wolfram

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -99,16 +99,35 @@ contexts:
       push: comment-block
 
   comment-block:
-      - meta_scope: comment.block.wolfram
-      - match: \(\*
-        push: comment-block
-      - match: \*\)
-        pop: true
+    - meta_scope: comment.block.wolfram
+    - match: \(\*
+      push: comment-block
+    - match: \*\)
+      pop: true
 
   literals:
-    # numbers, with base, scientific notation, precision or accuracy
-    - match: ([0-9]+\^\^)?{{number}}(\`\`?({{number}})?)?(\*\^{{number}})?
-      scope: constant.numeric.wolfram
+    - match: |-
+        (?x)
+        (?:
+          ([1-9]\d*\^\^)                                  # base
+          ((?:[[:alnum:]]+\.?|\.[[:alnum:]])[[:alnum:]]*) # value
+          |
+          ({{number}})                                    # value
+        )
+        (?:
+          (\`\`(?:{{number}})?)                           # accuracy
+          |
+          (\`(?:{{number}})?)                             # precision
+        )?
+        (\*\^[+-]?{{number}})?                            # exponent
+      scope: meta.numeric.wolfram
+      captures:
+        1: constant.numeric.base.wolfram
+        2: constant.numeric.wolfram
+        3: constant.numeric.wolfram
+        4: constant.numeric.accuracy.wolfram
+        5: constant.numeric.precision.wolfram
+        6: constant.numeric.exponent.wolfram
 
     # built-in symbols
     - match: ((?:System`)?{{built_in_numeric_constants}})

--- a/WolframLanguage.sublime-syntax
+++ b/WolframLanguage.sublime-syntax
@@ -300,7 +300,7 @@ contexts:
         1: punctuation.section.braces.begin.wolfram
         2: variable.parameter.wolfram
       push: meta-parameter
-    - match: (?=[\s\S])
+    - match: (?=\S)
       pop: true
 
   localized:

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -131,9 +131,13 @@
 
   Image[Red, Interleaving -> True]
 (*^^^^^ variable.function *)
-(*      ^ constant.language *) (* seems wrong to me *)
+(*      ^ constant.language *)
 (*           ^^^^^^^^^^^^ variable.function.wolfram *)
 (*                        ^^ keyword.operator *)
+
+  a ~ f ~ b ~ g ~ c
+(*    ^ variable.function *)
+(*            ^ variable.function *)
 
 (* PATTERNS *)
 
@@ -197,6 +201,9 @@
 (*^ entity.name.function  *)
 
   f = Function[x, x ^ 2]
+(*^ entity.name.function *)
+
+  f = # ^ 2 &;
 (*^ entity.name.function *)
 
   f[[]]

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -132,8 +132,17 @@
   Image[Red, Interleaving -> True]
 (*^^^^^ variable.function *)
 (*      ^ constant.language *)
-(*           ^^^^^^^^^^^^ variable.function.wolfram *)
+(*           ^^^^^^^^^^^^ variable.parameter *)
 (*                        ^^ keyword.operator *)
+
+  Sum[x, {x, 1, 100}]
+(*        ^ variable.parameter *)
+
+  Map[func, list]
+(*    ^^^^ variable.function *)
+
+  TakeWhile[list, func]
+(*                ^^^^ variable.function *)
 
   a ~ f ~ b ~ g ~ c
 (*    ^ variable.function *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -8,26 +8,24 @@
 
 (* NUMBERS *)
 
-   11
-(* ^^ constant.numeric *)
-   .11
-(* ^^^ constant.numeric *)
-   11.
-(* ^^^ constant.numeric *)
-   11.11
-(* ^^^^^ constant.numeric *)
-   11.11`
-(* ^^^^^^ constant.numeric *)
-   11.11`11
-(* ^^^^^^^^ constant.numeric *)
-   11.11``11
-(* ^^^^^^^^^ constant.numeric *)
-   11^^11.11
-(* ^^^^^^^^^ constant.numeric *)
-   11.11*^11
-(* ^^^^^^^^^ constant.numeric *)
-   11^^11.11`11*^11
-(* ^^^^^^^^^^^^^^^^^ constant.numeric *)
+  11`
+(*^^ constant.numeric *)
+(*  ^ constant.numeric.precision *)
+  11.`11
+(*^^^ constant.numeric *)
+(*   ^^^ constant.numeric.precision *)
+  .11``
+(*^^^ constant.numeric *)
+(*   ^^ constant.numeric.accuracy *)
+  11.11``
+(*^^^^^ constant.numeric *)
+(*     ^^ constant.numeric.accuracy *)
+  11^^1a
+(*^^^^ constant.numeric.base *)
+(*    ^^ constant.numeric *)
+  11.11*^-11
+(*^^^^^ constant.numeric.wolfram *)
+(*     ^^^^^ constant.numeric.exponent *)
 
 (* NUMERIC CONSTANTS *)
 

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -18,8 +18,16 @@
 (* ^^^^^ constant.numeric *)
    11.11`
 (* ^^^^^^ constant.numeric *)
-   11.11`11.11
-(* ^^^^^^^^^^^ constant.numeric *)
+   11.11`11
+(* ^^^^^^^^ constant.numeric *)
+   11.11``11
+(* ^^^^^^^^^ constant.numeric *)
+   11^^11.11
+(* ^^^^^^^^^ constant.numeric *)
+   11.11*^11
+(* ^^^^^^^^^ constant.numeric *)
+   11^^11.11`11*^11
+(* ^^^^^^^^^^^^^^^^^ constant.numeric *)
 
 (* NUMERIC CONSTANTS *)
 
@@ -45,6 +53,8 @@
 (*^ keyword.operator.arithmetic*)
   *
 (*^ keyword.operator.arithmetic*)
+  ^
+(*^ keyword.operator.arithmetic*)
 
   !
 (*^ keyword.operator.logical*)
@@ -69,19 +79,19 @@
 (*^^^ keyword.operator.comparison*)
 
    @
-(* ^ keyword.operator *)
+(* ^ keyword.operator.call *)
    @@
-(* ^^ keyword.operator *)
+(* ^^ keyword.operator.call *)
    @@@
-(* ^^^ keyword.operator *)
+(* ^^^ keyword.operator.call *)
    @*
-(* ^^ keyword.operator *)
+(* ^^ keyword.operator.call *)
    /*
-(* ^^ keyword.operator *)
+(* ^^ keyword.operator.call *)
    /@
-(* ^^ keyword.operator *)
+(* ^^ keyword.operator.call *)
    /;
-(* ^^ keyword.operator *)
+(* ^^ keyword.operator.condition *)
    //
 (* ^^ keyword.operator *)
    /:
@@ -97,7 +107,13 @@
    <->
 (* ^^^ keyword.operator *)
 
+
 (* VARIABLES *)
+
+  %%%
+(*^^^ storage.type.Out *)
+  %12
+(*^^^ storage.type.Out *)
 
   f[x]
 (*^ variable.function*)
@@ -179,6 +195,9 @@
 
   f[x_] /; x > 0 := x
 (*^ entity.name.function  *)
+
+  f = Function[x, x ^ 2]
+(*^ entity.name.function *)
 
   f[[]]
 

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -17,9 +17,9 @@
   .11``
 (*^^^ constant.numeric *)
 (*   ^^ constant.numeric.accuracy *)
-  11.11``
+  11.11``11
 (*^^^^^ constant.numeric *)
-(*     ^^ constant.numeric.accuracy *)
+(*     ^^^^ constant.numeric.accuracy *)
   11^^1a
 (*^^^^ constant.numeric.base *)
 (*    ^^ constant.numeric *)
@@ -153,11 +153,12 @@
 
   var_head
 (*^^^^^^^^ meta.parameter *)
-(*^^^^ variable.parameter *)
+(*^^^ variable.parameter *)
+(*   ^ variable.parameter.blank *)
 (*    ^^^^ variable.parameter.head *)
 
   var__head : foo
-(*         ^ meta.pattern keyword.operator.Optional *)
+(*          ^ meta.pattern keyword.operator.Optional *)
 
   var___head ? EvenQ
 (*           ^ meta.pattern keyword.operator.PatternTest *)

--- a/syntax_test_wolfram_language.wl
+++ b/syntax_test_wolfram_language.wl
@@ -148,27 +148,28 @@
 
 (* PATTERNS *)
 
-  var_head  foo
-(*^^^^^^^^ meta.pattern.blank.wolfram variable.parameter.wolfram *)
-(*          ^ variable.other *)
+  _.
+(*^^ variable.parameter.default *)
 
-  var_head:foo
-(*^^^^^^^^ meta.pattern.blank.wolfram variable.parameter.wolfram *)
-(*        ^ meta.pattern.blank.wolfram keyword.operator.Optional.wolfram *)
-(*         ^^^ variable.other *)
+  var_head
+(*^^^^^^^^ meta.parameter *)
+(*^^^^ variable.parameter *)
+(*    ^^^^ variable.parameter.head *)
 
-  var_head ? EvenQ
-(*^^^^^^^^ meta.pattern.blank.wolfram variable.parameter.wolfram *)
-(*         ^ meta.pattern.blank.wolfram keyword.operator.PatternTest.wolfram *)
-(*           ^^^^^ variable.function *)
+  var__head : foo
+(*         ^ meta.pattern keyword.operator.Optional *)
+
+  var___head ? EvenQ
+(*           ^ meta.pattern keyword.operator.PatternTest *)
 
   var: patt ? EvenQ : foo
-(*^^^ variable.parameter.wolfram *)
-(*   ^ keyword.operator.Pattern.wolfram *)
-(*      ^^^ meta.pattern.wolfram variable.other *)
-(*          ^ meta.pattern.wolfram keyword.operator.PatternTest.wolfram *)
-(*            ^^^^^ meta.pattern.wolfram variable.function *)
-(*                  ^ keyword.operator.Optional.wolfram *)
+(*^^^ variable.parameter *)
+(*   ^ keyword.operator.Pattern *)
+(*     ^^^^^^^^^^^^ meta.pattern *)
+(*     ^^^^ variable.other*)
+(*          ^ keyword.operator.PatternTest *)
+(*            ^^^^^ variable.function *)
+(*                  ^ keyword.operator.Optional *)
 (*                    ^^^ variable.other *)
 
 


### PR DESCRIPTION
Some of the changes are proposals and others are features.

1. **[Adjustment]** Add context `declarations` into `expressions` for supporting following condition:
```mathematica
entranceFunction = Module[{internalFunc},
    internalFunc[foo_] := bar;
    Return[doSomethingWith[internalFunc]];
]
```
2. **[Chore]** Delete unnecessary regex grouping and quotation marks.
3. **[Feature] Support numbers with base, scientific notation, precision or accuracy.** See [here](https://reference.wolfram.com/language/tutorial/InputSyntax.html).
```mathematica
   11^^11.11`11*^11
(* ^^^^^^^^^^^^^^^^^ constant.numeric *)
```
4. **[Adjustment]** Display `built_in_options` with `variable.parameter`. I know this is not that accurate, but much better than `variable.function`. Any ideas for this scope are welcomed.
5. **[Feature] Support shorthand syntax for [Out](https://reference.wolfram.com/language/ref/Out.html).**
```mathematica
  %%%
(*^^^ storage.type.Out *)
  %12
(*^^^ storage.type.Out *)
```
6. **[Feature] Support operator for [Power](https://reference.wolfram.com/language/ref/Power.html).**
7. **[Adjustment]** Display `&` with `variable.function` instead of `keyword.operator`. I think this would be more appropriate.
8. **[Break]** Remove the rule below. I don't know what does a prefix have to do with "constant".
```yaml
match: ((?:{{symbol}}`)*(\${{symbol}}))(?=\s*:?=)
scope: entity.name.constant.wolfram
```
9. **[Feature] Support shorthand syntax for [Infix](https://reference.wolfram.com/language/ref/Infix.html).**
```mathematica
  a ~ f ~ b ~ g ~ c
(*    ^ variable.function *)
(*            ^ variable.function *)
```
10. **[Feature] Support operator for [Definition](https://reference.wolfram.com/language/ref/Definition.html) and [FullDefinition](https://reference.wolfram.com/language/ref/FullDefinition.html).**
11. **[Adjustment]** Better display with specific functions, for example:
```mathematica
  Sum[x, {x, 1, 100}]
(*        ^ variable.parameter *)
  Map[func, list]
(*    ^^^^ variable.function *)
  TakeWhile[list, func]
(*                ^^^^ variable.function *)
```
These functions are currently listed as variables. With further development of branch `new-build-system`, we can easily generate them within lines of code.
